### PR TITLE
Make icons more flexible

### DIFF
--- a/src/model/LiveAtlasMapDefinition.ts
+++ b/src/model/LiveAtlasMapDefinition.ts
@@ -139,21 +139,23 @@ export default class LiveAtlasMapDefinition implements LiveAtlasTileLayerOptions
 			return this.icon;
 		}
 
+		let mapName = this.name.split(/[^a-zA-Z\d]/, 1)[0];
+
 		switch(this.world.dimension) {
 			case 'nether':
 				worldType = 'nether';
-				mapType = ['surface', 'nether'].includes(this.name) ? 'surface' : 'flat';
+				mapType = ['surface', 'nether'].includes(mapName) ? 'surface' : 'flat';
 				break;
 
 			case 'end':
 				worldType = 'the_end';
-				mapType = ['surface', 'the_end'].includes(this.name) ? 'surface' : 'flat';
+				mapType = ['surface', 'the_end'].includes(mapName) ? 'surface' : 'flat';
 				break;
 
 			case 'overworld':
 			default:
 				worldType = 'world';
-				mapType = ['surface', 'flat', 'biome', 'cave'].includes(this.name) ? this.name : 'flat';
+				mapType = ['surface', 'flat', 'biome', 'cave'].includes(mapName) ? this.name : 'flat';
 				break;
 		}
 

--- a/src/model/LiveAtlasMapDefinition.ts
+++ b/src/model/LiveAtlasMapDefinition.ts
@@ -155,7 +155,7 @@ export default class LiveAtlasMapDefinition implements LiveAtlasTileLayerOptions
 			case 'overworld':
 			default:
 				worldType = 'world';
-				mapType = ['surface', 'flat', 'biome', 'cave'].includes(mapName) ? this.name : 'flat';
+				mapType = ['surface', 'flat', 'biome', 'cave'].includes(mapName) ? mapName : 'flat';
 				break;
 		}
 


### PR DESCRIPTION
If you have more than one map per world with the same type, you have to use different names as identifiers.

Default maps for overworld: flat, surface and cave
Multiple maps with different perspectives: flat, surface_se, surface_sw, surface_nw, surface_ne, cave_se, cave_sw, cave_nw and cave_ne

The SVG icons will defined by the map name. In this case maps like surface_se will not detected as surface. This pull request changes the detection to the first part of the name. The name will split on every non-alphanumeric character.

We use this on our servers. Here some example: https://map.julieka.community