### PR TITLE
Squaremap-signs injection attack vector

### DIFF
--- a/src/providers/Pl3xmapMapProvider.ts
+++ b/src/providers/Pl3xmapMapProvider.ts
@@ -33,7 +33,7 @@ import {MutationTypes} from "@/store/mutation-types";
 import {ActionTypes} from "@/store/action-types";
 import LiveAtlasMapDefinition from "@/model/LiveAtlasMapDefinition";
 import MapProvider from "@/providers/MapProvider";
-import {getBoundsFromPoints, getMiddle, stripHTML, titleColoursRegex, validateConfigURL} from "@/util";
+import {cleanHTML, getBoundsFromPoints, getMiddle, stripHTML, titleColoursRegex, validateConfigURL} from "@/util";
 import {LiveAtlasMarkerType} from "@/util/markers";
 import {Pl3xmapTileLayer} from "@/leaflet/tileLayer/Pl3xmapTileLayer";
 import {LiveAtlasTileLayer, LiveAtlasTileLayerOptions} from "@/leaflet/tileLayer/LiveAtlasTileLayer";
@@ -334,7 +334,7 @@ export default class Pl3xmapMapProvider extends MapProvider {
 			iconUrl: `${this.config}images/icon/registered/${marker.icon || "default"}.png`,
 
 			tooltip: marker.tooltip ? stripHTML(marker.tooltip) : '',
-			tooltipHTML: marker.tooltip,
+			tooltipHTML: marker.tooltip? cleanHTML(marker.tooltip) : '',
 			popup: marker.popup,
 			isPopupHTML: true,
 		};

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,7 +29,7 @@ import {globalMessages, serverMessages} from "../messages";
 import ConfigurationError from "@/errors/ConfigurationError";
 
 const documentRange = document.createRange(),
-	brToSpaceRegex = /<br \/>/g;
+	brToSpaceRegex = /<br ?\/?>/g;
 
 export const titleColoursRegex = /§[0-9a-f]/ig;
 export const netherWorldNameRegex = /[_\s]?nether([\s_]|$)/i;

--- a/src/util.ts
+++ b/src/util.ts
@@ -245,6 +245,16 @@ export const stripHTML = (text: string) => {
 }
 
 /**
+ * Cleans HTML from the given string using a contextual {@link DocumentFragment}
+ * @param {string} text The text to clean HTML from
+ * @returns {string} The given text with all HTML except <br>s
+ */
+export const cleanHTML = (text: string) => {
+	const textContent = documentRange.createContextualFragment(text.replace(brToSpaceRegex,'uuddlrlrbaStartSelect')).textContent || '';
+	return textContent.replace(/uuddlrlrbaStartSelect/g, "<br/>");
+}
+
+/**
  * Default success callback function for VueClipboard, will display a notification with the configured copy success
  * message
  */


### PR DESCRIPTION
I'm replacing the `<br/>`s by `uuddlrlrbaStartSelect` (Konami code). The reason for this is because it's long enough to not fit on a sign and thus safe to use.

I don't run Dynmap so I'm not sure if that issue would be happening there as well.

Fixes #627 